### PR TITLE
Update logging for FaceRunner and Open WebUI services

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,166 +1,118 @@
 # FaceRunner Features
 
-This document outlines all the features required to make FaceRunner a fully functional tool for managing Ollama and Open WebUI with Hugging Face models. Features are categorized by status: ✅ Implemented, 🚧 In Progress, or 📋 Planned.
+This document outlines the features and roadmap for FaceRunner, a tool for managing Ollama, Open WebUI, and Hugging Face models—fully local, no containers or Docker required.
 
 ## Core Features
 
-### Container Management
-
-- ✅ **Docker Container Setup**: Automatically start Ollama and Open WebUI containers with proper configuration
-- ✅ **GPU Support**: Enable GPU acceleration for Ollama when available
-- ✅ **Volume Management**: Persist model data and user data across container restarts
-- ✅ **Port Mapping**: Configure network ports (11434 for Ollama, 8080 for WebUI) for local and remote access
-
-### Model Management
-
-- ✅ **Model Pulling**: Download and install Hugging Face models via Ollama
-- ✅ **Model Selection**: Support for various GGUF models from Hugging Face
-- ✅ **Model Storage**: Local storage and caching of downloaded models
-
-### Network and Security
-
-- ✅ **Network Configuration**: Bind containers to all network interfaces for remote access
-- ✅ **Firewall Management**: Automatically configure firewall rules for required ports on Linux/Windows/macOS
-- ✅ **Host IP Detection**: Automatically detect and use the host's IP address for container communication
-- 🚧 **Secure Key Generation**: Generate proper secret keys for Open WebUI (currently uses placeholder)
-- 📋 **SSL/TLS Support**: Add HTTPS support for secure remote access
-- 📋 **Authentication**: Implement user authentication for the web interface
+- **One-command setup and start:** `facerunner setup` prepares and launches all services.
+- **Automatic model name conversion:** Hugging Face model names are converted to Ollama-compatible names in CLI and web UI.
+- **Model management:** List, pull, and remove models via CLI and web UI. Parameter size selection and popular model suggestions in the UI.
+- **Service orchestration:** Starts Ollama, Open WebUI, and FaceRunner Web UI as local processes.
+- **Streamlit-based management UI:** Graphical interface for model management, conversion, and service status.
+- **Clear error feedback:** Improved error handling and messaging for setup and service management.
+- **Simple start/stop:** `facerunner start` and `facerunner stop` launch and kill all associated services with friendly status messages.
+- **No firewall or network config needed:** Everything runs on localhost.
 
 ## CLI Features
 
-### Command Line Interface
-
-- ✅ **Setup Command**: One-command initialization of the entire environment
-- ✅ **Pull Command**: Download specific models with progress indication
-- ✅ **Start/Stop Commands**: Control running state of services
-- ✅ **Verify Command**: Test accessibility of Ollama API and WebUI
-- ✅ **Configure Network Command**: Manual network and firewall setup
-- ✅ **VS Code Integration Command**: Generate configuration for Continue extension
-- ✅ **Web UI Command**: Launch the Streamlit-based web interface
-- 📋 **Status Command**: Show current state of containers and services
-- 📋 **Logs Command**: Display container logs for debugging
-- 📋 **Update Command**: Check for and apply updates to FaceRunner
-
-### CLI Enhancements
-
-- 📋 **Interactive Mode**: Guided setup with prompts for user preferences
-- 📋 **Configuration File**: Support for YAML/JSON config files for custom settings
-- 📋 **Batch Operations**: Support for pulling multiple models at once
-- 📋 **Dry Run Mode**: Preview actions without executing them
+- **Setup Command:** One-command initialization of the entire environment.
+- **Pull Command:** Download specific models with progress indication.
+- **Start/Stop Commands:** Control running state of services.
+- **Verify Command:** Test accessibility of Ollama API and WebUI.
+- **Web UI Command:** Launch the Streamlit-based web interface.
+- **VS Code Integration Command:** Generate configuration for Continue extension.
+- **Update Command:** Check for and apply updates to FaceRunner.
+- **Interactive Mode (Planned):** Guided setup with prompts for user preferences.
+- **Configuration File (Planned):** Support for YAML/JSON config files for custom settings.
+- **Batch Operations (Planned):** Support for pulling multiple models at once.
+- **Dry Run Mode (Planned):** Preview actions without executing them.
+- **Status Command (Planned):** Show current state of services.
+- **Logs Command (Planned):** Display service logs for debugging.
 
 ## Web UI Features
 
-### Streamlit Interface
+- **Dashboard:** Main interface with buttons for all major operations.
+- **Setup Interface:** Guided setup process with progress indicators.
+- **Model Management:** Pull models with input field and status feedback.
+- **Service Control:** Start/stop buttons with real-time status updates.
+- **Verification Tools:** Test connectivity with detailed results.
+- **VS Code Integration:** Generate config files with IP input.
+- **Model Browser (Planned):** Browse available models from Ollama and Hugging Face.
+- **Chat Interface Integration (Planned):** Direct link to Open WebUI chat.
+- **Log Viewer (Planned):** Display and filter service logs in the web UI.
+- **Settings Panel (Planned):** Configure FaceRunner preferences through the web.
+- **Multi-user Support (Planned):** Basic user management for shared deployments.
+- **Real-time Monitoring (Planned):** Live status dashboard with service metrics.
 
-- ✅ **Dashboard**: Main interface with buttons for all major operations
-- ✅ **Setup Interface**: Guided setup process with progress indicators
-- ✅ **Model Management**: Pull models with input field and status feedback
-- ✅ **Service Control**: Start/stop buttons with real-time status updates
-- ✅ **Verification Tools**: Test connectivity with detailed results
-- ✅ **Network Configuration**: Interface for firewall and network settings
-- ✅ **VS Code Integration**: Generate config files with IP input
+## Model and Data Features
 
-### Web UI Enhancements
-
-- 📋 **Real-time Monitoring**: Live status dashboard with container metrics
-- 📋 **Model Browser**: Browse available models from Ollama
-- 📋 **Chat Interface Integration**: Direct link to Open WebUI chat
-- 📋 **Log Viewer**: Display and filter container logs in the web UI
-- 📋 **Settings Panel**: Configure FaceRunner preferences through the web
-- 📋 **Multi-user Support**: Basic user management for shared deployments
-
-## Advanced Features
-
-### Monitoring and Analytics
-
-- 📋 **Performance Monitoring**: Track GPU usage, memory consumption, and inference times
-- 📋 **Usage Statistics**: Log model usage patterns and popular models
-- 📋 **Health Checks**: Automated monitoring of service availability
-- 📋 **Alert System**: Notifications for service failures or resource issues
-
-### Integration Features
-
-- ✅ **VS Code Continue Integration**: Generate config for seamless IDE integration
-- 📋 **Jupyter Notebook Integration**: Support for notebook environments
-- 📋 **API Endpoints**: REST API for programmatic access to FaceRunner functions
-- 📋 **Webhook Support**: Callbacks for events like model downloads or service status changes
-
-### Deployment and Scaling
-
-- 📋 **Docker Compose Support**: Generate docker-compose.yml for advanced deployments
-- 📋 **Kubernetes Manifests**: Support for container orchestration
-- 📋 **Multi-host Deployment**: Manage multiple FaceRunner instances
-- 📋 **Load Balancing**: Distribute requests across multiple Ollama instances
-
-### Model and Data Features
-
-- 📋 **Custom Model Support**: Upload and serve custom models
-- 📋 **Model Optimization**: Automatic quantization and optimization
-- 📋 **Dataset Management**: Tools for managing training datasets
-- 📋 **Backup and Restore**: Backup/restore model data and configurations
+- **Custom Model Support (Planned):** Upload and serve custom models.
+- **Universal Hugging Face Model & Transformer Support (Planned):** Add, run, and manage all types of models and transformers from Hugging Face (not limited to GGUF/Ollama-compatible models).
+- **Model Optimization (Planned):** Automatic quantization and optimization.
+- **Dataset Management (Planned):** Tools for managing training datasets.
+- **Backup and Restore (Planned):** Backup/restore model data and configurations.
 
 ## Platform Support
 
-### Operating Systems
+- **Linux:** Full support.
+- **macOS:** Support with manual firewall configuration guidance.
+- **Windows:** Support with Windows Firewall management.
+- **NVIDIA GPU:** CUDA support for GPU acceleration.
+- **AMD GPU (Planned):** ROCm support for AMD GPUs.
+- **Apple Silicon (Planned):** Optimized support for M1/M2 Macs.
+- **CPU-only (Planned):** Fallback for systems without GPU support.
 
-- ✅ **Linux**: Full support with UFW firewall management
-- ✅ **macOS**: Support with manual firewall configuration guidance
-- ✅ **Windows**: Support with Windows Firewall management
-- 📋 **Docker Desktop**: Enhanced support for Docker Desktop environments
+## Advanced Features (Planned)
 
-### Hardware Acceleration
-
-- ✅ **NVIDIA GPU**: CUDA support for GPU acceleration
-- 📋 **AMD GPU**: ROCm support for AMD GPUs
-- 📋 **Apple Silicon**: Optimized support for M1/M2 Macs
-- 📋 **CPU-only**: Fallback for systems without GPU support
+- **Performance Monitoring:** Track GPU usage, memory consumption, and inference times.
+- **Usage Statistics:** Log model usage patterns and popular models.
+- **Health Checks:** Automated monitoring of service availability.
+- **Alert System:** Notifications for service failures or resource issues.
+- **API Endpoints:** REST API for programmatic access to FaceRunner functions.
+- **Webhook Support:** Callbacks for events like model downloads or service status changes.
+- **Multi-host Deployment:** Manage multiple FaceRunner instances.
+- **Load Balancing:** Distribute requests across multiple Ollama instances.
 
 ## Quality Assurance
 
-### Testing
+- **Unit Tests (Planned):** Test individual functions and modules.
+- **Integration Tests (Planned):** Test end-to-end workflows.
+- **UI Tests (Planned):** Automated testing of web interface.
+- **Performance Tests (Planned):** Benchmark model loading and inference.
 
-- 📋 **Unit Tests**: Test individual functions and modules
-- 📋 **Integration Tests**: Test end-to-end workflows
-- 📋 **UI Tests**: Automated testing of web interface
-- 📋 **Performance Tests**: Benchmark model loading and inference
+## Documentation
 
-### Documentation
+- **README:** Basic installation and usage instructions.
+- **API Documentation (Planned):** Detailed API reference.
+- **Troubleshooting Guide (Planned):** Common issues and solutions.
+- **Developer Guide (Planned):** Contributing guidelines and architecture.
 
-- ✅ **README**: Basic installation and usage instructions
-- 📋 **API Documentation**: Detailed API reference
-- 📋 **Troubleshooting Guide**: Common issues and solutions
-- 📋 **Developer Guide**: Contributing guidelines and architecture
+## Maintenance
 
-### Maintenance
+- **Automated Updates (Planned):** Check for FaceRunner and dependency updates.
+- **Dependency Management (Planned):** Keep Python packages up to date.
+- **Security Audits (Planned):** Regular security vulnerability checks.
+- **Backup Strategies (Planned):** Automated backup of configurations and data.
 
-- 📋 **Automated Updates**: Check for FaceRunner and dependency updates
-- 📋 **Dependency Management**: Keep Python packages up to date
-- 📋 **Security Audits**: Regular security vulnerability checks
-- 📋 **Backup Strategies**: Automated backup of configurations and data
-
-## Future Roadmap
+## Roadmap
 
 ### Short Term (Next Release)
-
-- Implement secure key generation
-- Add status and logs commands to CLI
-- Enhance web UI with real-time monitoring
-- Add configuration file support
+- Secure key generation
+- Status and logs commands in CLI
+- Real-time monitoring in web UI
+- Configuration file support
 
 ### Medium Term (3-6 Months)
-
 - Multi-user authentication
 - API endpoints for external integrations
 - Advanced monitoring and analytics
 - Support for additional model formats
 
 ### Long Term (6+ Months)
-
-- Kubernetes deployment support
 - Enterprise features (audit logs, compliance)
 - Plugin system for extensibility
 - Mobile app companion
 
 ---
 
-This feature list will be updated as development progresses. Features marked as 📋 Planned are prioritized based on user feedback and community needs.
+This feature list will be updated as development progresses. Features marked as "Planned" are prioritized based on user feedback and community needs.

--- a/src/facerunner/__init__.py
+++ b/src/facerunner/__init__.py
@@ -168,12 +168,16 @@ def launch_webui_background():
             click.echo("✅ Existing web UI terminated.")
 
         click.echo("🚀 Launching FaceRunner web UI in background...")
+
+        log_path = os.path.expanduser("~/.facerunner/logs/facerunner.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        log_file = open(log_path, "a")
         process = subprocess.Popen([
             "streamlit", "run", "src/main.py",
             "--server.address", "0.0.0.0",
             "--server.port", str(STREAMLIT_PORT),
             "--server.headless", "true"
-        ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        ], stdout=log_file, stderr=log_file)
 
         time.sleep(2)
         if check_webui_running():
@@ -206,10 +210,13 @@ def setup(verbose):
       click.echo("🚀 Starting Ollama service on localhost...")
       env = os.environ.copy()
       env["OLLAMA_HOST"] = "localhost"
-      proc = subprocess.Popen(["ollama", "serve"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+      log_path = os.path.expanduser("~/.facerunner/logs/ollama.log")
+      os.makedirs(os.path.dirname(log_path), exist_ok=True)
+      log_file = open(log_path, "a")
+      proc = subprocess.Popen(["ollama", "serve"], stdout=log_file, stderr=log_file, env=env)
       time.sleep(2)
       return proc
-      # Check if ollama is installed
+    # Check if ollama is installed
     def is_ollama_installed():
         return subprocess.run(["which", "ollama"], capture_output=True).returncode == 0
 
@@ -255,9 +262,14 @@ def setup(verbose):
                 return
         # Start Open WebUI locally
         click.echo("🚀 Starting Open WebUI locally...")
+        log_path = os.path.expanduser("~/.facerunner/logs/openwebui.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        log_file = open(log_path, "a")
         webui_proc = subprocess.Popen([
-            "open-webui", "serve", "--host", "0.0.0.0", "--port", str(WEBUI_PORT)
-        ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            "open-webui", "serve",
+            "--host", "0.0.0.0",
+            "--port", str(WEBUI_PORT)
+        ], stdout=log_file, stderr=log_file)
         time.sleep(2)
         click.echo(f"🌐 Open WebUI (chat interface): http://localhost:{WEBUI_PORT}")
         # Start FaceRunner web UI (Streamlit)

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,11 @@
 FaceRunner Web UI - Main application entry point.
 """
 
+
 import streamlit as st
 import time
+import logging
+import os
 
 from system_utils import get_gpu_info, get_host_ip
 from network_utils import verify_accessibility, configure_network
@@ -21,6 +24,15 @@ OLLAMA_PORT = 11434
 WEBUI_PORT = 8080
 
 def main():
+    # Setup logging to ~/.facerunner/logs/facerunner.log
+    log_path = os.path.expanduser("~/.facerunner/logs/facerunner.log")
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(message)s',
+        handlers=[logging.FileHandler(log_path), logging.StreamHandler()]
+    )
+
     # Custom CSS to reduce top margin and bring sidebar closer to the top
     st.markdown("""
         <style>
@@ -96,10 +108,12 @@ def main():
         "🔗 VS Code Integration",
         "🛠️ Setup & Management",
         "⚙️ Settings"
+            ,"📝 Log Viewer"
     ]
+
     if "active_tab" not in st.session_state:
         st.session_state["active_tab"] = 0
-    tab1, tab2, tab3, tab4, tab5 = st.tabs(tab_labels)
+    tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(tab_labels)
     active_tab = st.session_state["active_tab"]
 
     with tab1:
@@ -135,6 +149,10 @@ def main():
 
     with tab5:
         create_settings_ui()
+
+        with tab6:
+            from ui_components import log_viewer_ui
+            log_viewer_ui()
 
 if __name__ == "__main__":
     try:

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -99,8 +99,25 @@ def create_model_browser_ui():
                     else:
                         st.error(msg)
             st.markdown("---")
-    else:
-        st.info("No models found.")
+
+
+def log_viewer_ui():
+    """Streamlit UI for viewing and filtering service logs."""
+    st.header("Log Viewer")
+    import os
+    log_files = {
+        "FaceRunner": os.path.expanduser("~/.facerunner/logs/facerunner.log"),
+        "Ollama": os.path.expanduser("~/.facerunner/logs/ollama.log"),
+        "Open WebUI": os.path.expanduser("~/.facerunner/logs/openwebui.log")
+    }
+    service = st.selectbox("Select Service", list(log_files.keys()))
+    level = st.selectbox("Log Level", ["ALL", "INFO", "WARNING", "ERROR"])
+    search = st.text_input("Search logs")
+    log_path = log_files[service]
+    level_filter = None if level == "ALL" else level
+    from system_utils import read_service_logs
+    logs = read_service_logs(log_path, level=level_filter, search=search)
+    st.text_area("Logs", "\n".join(logs), height=400)
 """
 FaceRunner UI Components - Streamlit UI components and helpers.
 """


### PR DESCRIPTION
- Fix Open WebUI launch: remove unsupported --log-file argument, revert to stdout/stderr redirection for logging
- Ensure Open WebUI logs are written to ~/.facerunner/logs/openwebui.log
- Confirm FaceRunner and Ollama services also log to ~/.facerunner/logs/
- Maintain compatibility with current Open WebUI CLI
- Improve reliability of log viewer feature in the web UI by ensuring all service logs are captured in user-